### PR TITLE
Change notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,20 @@ let input = document.getElementById('my-input');
 performTextSubstitution(input);
 ```
 
-We use the [`system-preferences`](http://electron.atom.io/docs/api/system-preferences/#systempreferences) API to get the user's text substitutions, as well as watch for changes.
+We use the [`system-preferences`](http://electron.atom.io/docs/api/system-preferences/#systempreferences) API to get the user's text substitutions. If you have smart quotes or dashes enabled, we'll handle that too.
 
-If you have smart quotes or dashes enabled, we'll handle that too.
+#### Change notifications
+
+To receive text preference change notifications, you'll need to call an additional method, that only works in the main process. This should be called before any renderer starts using text substitutions.
+
+``` js
+import {listenForPreferenceChanges} from 'electron-text-substitutions';
+listenForPreferenceChanges();
+```
 
 ## API
+
+#### Renderer Process
 
 ``` js
 /**
@@ -42,4 +51,17 @@ If you have smart quotes or dashes enabled, we'll handle that too.
  * @return {Disposable}           A `Disposable` that will clean up everything this method did
  */
 performTextSubstitution(element);
+```
+
+#### Main Process
+
+``` js
+/**
+ * Subscribes to text preference changed notifications and notifies listeners
+ * in renderer processes. This method must be called from the main process, and
+ * should be called before any renderer process calls `performTextSubstitution`.
+ *
+ * @return {Disposable}  A `Disposable` that will clean up everything this method did
+ */
+listenForPreferenceChanges() {
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-text-substitutions",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "Substitute text in an input field based on OS X System Preferences",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -69,9 +69,8 @@ export default function performTextSubstitution(element, preferenceOverrides = n
 
 /**
  * Subscribes to text preference changed notifications and notifies listeners
- * in renderer processes. This method must be called from the browser process,
- * and should be called before any renderer process calls
- * `performTextSubstitution`.
+ * in renderer processes. This method must be called from the main process, and
+ * should be called before any renderer process calls `performTextSubstitution`.
  *
  * @return {Disposable}  A `Disposable` that will clean up everything this method did
  */


### PR DESCRIPTION
This PR adds support for change notifications. Adding a `remote` handler for `systemPreferences.subscribeNotification` while within a webview doesn't work (https://github.com/electron/electron/issues/6264), so we'll instead listen for changes in the main process and `ipc` them over.