### PR TITLE
Only substitute the word preceding the caret

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -241,11 +241,16 @@ function addInputListener(element, replacementItems) {
     }
   };
 
+  let pasteListener = () => {
+    ignoreEvent = true;
+  };
+
   let keyUpListener = () => {
     ignoreEvent = false;
   };
 
   element.addEventListener('keydown', keyDownListener, true);
+  element.addEventListener('paste', pasteListener, true);
   element.addEventListener('keyup', keyUpListener, true);
   element.addEventListener('input', inputListener);
 
@@ -253,6 +258,7 @@ function addInputListener(element, replacementItems) {
 
   return new Disposable(() => {
     element.removeEventListener('keydown', keyDownListener);
+    element.removeEventListener('paste', pasteListener);
     element.removeEventListener('keyup', keyUpListener);
     element.removeEventListener('input', inputListener);
 

--- a/test/index.js
+++ b/test/index.js
@@ -31,7 +31,7 @@ describe('the performTextSubstitution method', () => {
     assert.equal(input.value, 'everything I do deserves… ಠ_ಠ and more disapproval.');
   });
 
-  it('should handle multiple substitutions at once', () => {
+  it('should handle multiple substitutions', () => {
     let input = new MockInput('');
     performTextSubstitution(input, {
       substitutions: [
@@ -40,18 +40,21 @@ describe('the performTextSubstitution method', () => {
       ]
     });
 
-    input.inputText('here is a shrug, and a gaze of disapproval.');
+    input.inputText('here is a shrug,');
+    assert.equal(input.value, 'here is a ¯\\_(ツ)_/¯,');
+
+    input.inputText(' and a gaze of disapproval.');
     assert.equal(input.value, 'here is a ¯\\_(ツ)_/¯, and a gaze of ಠ_ಠ.');
   });
 
-  it('should only substitute the first if multiple matches occur', () => {
+  it('should only substitute word preceding the cursor', () => {
     let input = new MockInput('');
     performTextSubstitution(input, {
       substitutions: [{ replace: 'shrug', with: '¯\\_(ツ)_/¯' }]
     });
 
     input.inputText('multiple shrug shrug shrug ');
-    assert.equal(input.value, 'multiple ¯\\_(ツ)_/¯ shrug shrug ');
+    assert.equal(input.value, 'multiple shrug shrug ¯\\_(ツ)_/¯ ');
   });
 
   it('should handle the man known as shinypb', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -73,7 +73,7 @@ describe('the performTextSubstitution method', () => {
       useSmartDashes: true
     });
 
-    input.inputText('Hello (c) . look here -> or there <- (1/2) is less than (3/4) (r) .... (1/3) (tm)... ');
+    input.typeText('Hello (c) . look here -> or there <- (1/2) is less than (3/4) (r) .... (1/3) (tm)... ');
     assert.equal(input.value, 'Hello © . look here → or there ← ½ is less than ¾ ® … ⅓ ™… ');
   });
 
@@ -85,7 +85,7 @@ describe('the performTextSubstitution method', () => {
       useSmartDashes: true
     });
 
-    input.inputText('\'This is a single quote,\' she said--- \"And this is a double\" ');
+    input.typeText('\'This is a single quote,\' she said--- \"And this is a double\" ');
     assert.equal(input.value, '‘This is a single quote,’ she said— “And this is a double” ');
   });
 

--- a/test/mock-input.js
+++ b/test/mock-input.js
@@ -1,4 +1,5 @@
 import EventTarget from 'event-target-shim';
+import {Observable} from 'rx-lite';
 
 export default class MockInput extends EventTarget {
   constructor(initialText = "") {
@@ -17,6 +18,11 @@ export default class MockInput extends EventTarget {
     this.selectionStart = this.selectionEnd = this.value.length;
 
     if (dispatch) this.dispatchEvent({type: 'input'});
+  }
+
+  typeText(text) {
+    return Observable.fromArray(text)
+      .subscribe((character) => this.inputText(character));
   }
 
   clearText() {


### PR DESCRIPTION
When a block of text was inserted (typically from a paste), we'd search all of it, potentially making substitutions and changing the caret position. This is especially noticeable when inserting code with straight quotes while smart quotes is turned on.

Instead, we're only going to do substitutions on the word immediately preceding the caret. This provides a bit of an escape hatch for any unintended substitution.