### PR TITLE
Cache replacement items

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,7 @@ let input = document.getElementById('my-input');
 performTextSubstitution(input);
 ```
 
-We use the [`system-preferences`](http://electron.atom.io/docs/api/system-preferences/#systempreferences) API to get the user's text substitutions. If you have smart quotes or dashes enabled, we'll handle that too.
-
-#### Change notifications
-
-To receive text preference change notifications, you'll need to call an additional method, that only works in the main process. This should be called before any renderer starts using text substitutions.
-
-``` js
-import {listenForPreferenceChanges} from 'electron-text-substitutions';
-listenForPreferenceChanges();
-```
+We use the [`system-preferences`](http://electron.atom.io/docs/api/system-preferences/#systempreferences) API to get the user's text substitutions. If you have smart quotes or dashes enabled, we'll handle that too. If you change any of the system text preferences, the listener will be automatically updated.
 
 ## API
 
@@ -51,17 +42,4 @@ listenForPreferenceChanges();
  * @return {Disposable}           A `Disposable` that will clean up everything this method did
  */
 performTextSubstitution(element);
-```
-
-#### Main Process
-
-``` js
-/**
- * Subscribes to text preference changed notifications and notifies listeners
- * in renderer processes. This method must be called from the main process, and
- * should be called before any renderer process calls `performTextSubstitution`.
- *
- * @return {Disposable}  A `Disposable` that will clean up everything this method did
- */
-listenForPreferenceChanges() {
 ```

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.9.2",
-    "debug": "^2.2.0",
+    "debug-electron": "0.0.1",
     "lodash": "^4.13.1",
     "rx-lite": "^4.0.8"
   }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.9.2",
-    "debug-electron": "0.0.1",
+    "debug": "^2.2.0",
     "lodash": "^4.13.1",
     "rx-lite": "^4.0.8"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,12 @@
 import electron from 'electron';
-import {forEach, values, some} from 'lodash';
-import {Observable, Disposable, CompositeDisposable, SerialDisposable} from 'rx-lite';
+import {some} from 'lodash';
+import {Disposable, CompositeDisposable, SerialDisposable} from 'rx-lite';
 import {getSubstitutionRegExp, getSmartQuotesRegExp, getSmartDashesRegExp,
   scrubInputString, formatReplacement} from './regular-expressions';
 import {isUndoRedoEvent} from './undo-redo-event';
 
 const packageName = 'electron-text-substitutions';
-const d = process.type === 'browser' ?
-  require('debug')(packageName) :
-  console.log.bind(window.console);
-
-const registerForPreferenceChangedIpcMessage = `${packageName}-register-renderer`;
-const unregisterForPreferenceChangedIpcMessage = `${packageName}-unregister-renderer`;
-const preferenceChangedIpcMessage = `${packageName}-preference-changed`;
+const d = require('debug-electron')(packageName);
 
 const userDefaultsTextSubstitutionsKey = 'NSUserDictionaryReplacementItems';
 const userDefaultsSmartQuotesKey = 'NSAutomaticQuoteSubstitutionEnabled';
@@ -24,9 +18,7 @@ const textPreferenceChangedKeys = [
   'NSAutomaticDashSubstitutionEnabledChanged'
 ];
 
-let ipcMain, ipcRenderer, systemPreferences;
-let registeredWebContents = {};
-let replacementItems;
+let systemPreferences, replacementItems;
 
 /**
  * Adds an `input` event listener to the given element (an <input> or
@@ -46,99 +38,39 @@ export default function performTextSubstitution(element, preferenceOverrides = n
   if (!process || !process.type === 'renderer') throw new Error(`Not in an Electron renderer context`);
   if (process.platform !== 'darwin') throw new Error(`Only supported on OS X`);
 
-  ipcRenderer = ipcRenderer || electron.ipcRenderer;
   systemPreferences = systemPreferences || electron.remote.systemPreferences;
 
   if (!systemPreferences || !systemPreferences.getUserDefault) {
     throw new Error(`Electron ${process.versions.electron} is not supported`);
   }
 
-  ipcRenderer.send(registerForPreferenceChangedIpcMessage);
+  let currentAttach = assignDisposableToListener(element, preferenceOverrides);
+  let subscriptionIds = [];
+
+  // TODO: It'd be much more efficient to only subscribe these once, rather
+  // than for each input element.
+  for (let preferenceChangedKey of textPreferenceChangedKeys) {
+    subscriptionIds.push(systemPreferences.subscribeNotification(preferenceChangedKey, () => {
+      replacementItems = null;
+      d(`User modified ${preferenceChangedKey}, reattaching listener`);
+      assignDisposableToListener(element, preferenceOverrides, currentAttach);
+    }));
+  }
+
+  let changeHandlerDisposable = new Disposable(() => {
+    for (let subscriptionId of subscriptionIds) {
+      systemPreferences.unsubscribeNotification(subscriptionId);
+    }
+    d(`Cleaned up all listeners`);
+  });
+
+  let combinedDisposable = new CompositeDisposable(currentAttach, changeHandlerDisposable);
 
   window.addEventListener('beforeunload', () => {
-    d(`Window unloading, unregister any listeners`);
-    ipcRenderer.send(unregisterForPreferenceChangedIpcMessage);
+    combinedDisposable.dispose();
   });
 
-  let currentAttach = assignDisposableToListener(element, preferenceOverrides);
-
-  ipcRenderer.on(preferenceChangedIpcMessage, () => {
-    d(`User modified text preferences, reattaching listener`);
-    replacementItems = null;
-    assignDisposableToListener(element, preferenceOverrides, currentAttach);
-  });
-
-  return currentAttach;
-}
-
-/**
- * Subscribes to text preference changed notifications and notifies listeners
- * in renderer processes. This method must be called from the main process, and
- * should be called before any renderer process calls `performTextSubstitution`.
- *
- * @return {Disposable}  A `Disposable` that will clean up everything this method did
- */
-export function listenForPreferenceChanges() {
-  if (!process || !process.type === 'browser') throw new Error(`Not in an Electron browser context`);
-  if (process.platform !== 'darwin') throw new Error(`Only supported on OS X`);
-
-  ipcMain = ipcMain || electron.ipcMain;
-  systemPreferences = systemPreferences || electron.systemPreferences;
-
-  ipcMain.on(registerForPreferenceChangedIpcMessage, ({sender}) => {
-    let id = sender.getId();
-    d(`Registering webContents ${id} for preference changes`);
-    registeredWebContents[id] = { id, sender };
-  });
-
-  ipcMain.on(unregisterForPreferenceChangedIpcMessage, ({sender}) => {
-    d(`Unregistering webContents ${sender.getId()}`);
-    delete registeredWebContents[sender.getId()];
-  });
-
-  let notificationDisp = Observable.fromArray(textPreferenceChangedKeys)
-    .flatMap((key) => observableForPreferenceNotification(key))
-    .debounce(1000)
-    .subscribe(notifyAllListeners);
-
-  return new CompositeDisposable(
-    notificationDisp,
-    new Disposable(() => ipcMain.removeAllListeners(registerForPreferenceChangedIpcMessage)),
-    new Disposable(() => ipcMain.removeAllListeners(unregisterForPreferenceChangedIpcMessage))
-  );
-}
-
-/**
- * Creates an Observable that will `onNext` when the given key in
- * `NSUserDefaults` changes.
- *
- * @param  {String} preferenceChangedKey  The key to listen for
- * @return {Disposable}                   A Disposable that will unsubscribe the listener
- */
-function observableForPreferenceNotification(preferenceChangedKey) {
-  return Observable.create((subj) => {
-    let subscriberId = systemPreferences.subscribeNotification(preferenceChangedKey, () => {
-      d(`Got a ${preferenceChangedKey}`);
-      subj.onNext(preferenceChangedKey);
-    });
-
-    return new Disposable(() => systemPreferences.unsubscribeNotification(subscriberId));
-  });
-}
-
-/**
- * Sends an IPC message to each `WebContents` that is doing text substitution,
- * unless it has been destroyed, in which case remove it from our list.
- */
-function notifyAllListeners() {
-  forEach(values(registeredWebContents), ({id, sender}) => {
-    if (sender.isDestroyed() || sender.isCrashed()) {
-      d(`WebContents ${id} is gone, removing it`);
-      delete registeredWebContents[id];
-    } else {
-      sender.send(preferenceChangedIpcMessage);
-    }
-  });
+  return combinedDisposable;
 }
 
 function assignDisposableToListener(element, preferenceOverrides, currentAttach = null) {

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,9 @@ import {getSubstitutionRegExp, getSmartQuotesRegExp, getSmartDashesRegExp,
 import {isUndoRedoEvent} from './undo-redo-event';
 
 const packageName = 'electron-text-substitutions';
-const d = require('debug-electron')(packageName);
+const d = process.type === 'browser' ?
+  require('debug')(packageName) :
+  console.log.bind(window.console);
 
 const registerForPreferenceChangedIpcMessage = `${packageName}-register-renderer`;
 const unregisterForPreferenceChangedIpcMessage = `${packageName}-unregister-renderer`;
@@ -220,7 +222,7 @@ function addInputListener(element, replacementItems) {
 
       if (match && match.length === 3) {
         d(`Got a match of length ${match[0].length} at index ${match.index}: ${JSON.stringify(match)}`);
-        
+
         if (some(replacementItems, (item) => item.match === match[0])) {
           d(`The match is a prefix of another replacement item (${match[0]}), skip it`);
           continue;

--- a/src/index.js
+++ b/src/index.js
@@ -184,13 +184,17 @@ function getReplacementItems({substitutions, useSmartQuotes, useSmartDashes}) {
   d(`Found ${substitutions.length} substitutions in NSUserDictionaryReplacementItems`);
 
   // NB: Run each replacement string through our smart quotes & dashes regex,
-  // so that an input event doesn't cause chained substitutions. Also sort 
+  // so that an input event doesn't cause chained substitutions. Also sort
   // replacements by length, to handle nested substitutions.
+  let startTime = Date.now();
   let userDictionaryReplacements = substitutions
     .filter((substitution) => substitution.on !== false)
     .sort((a, b) => b.replace.length - a.replace.length)
     .map((substitution) => getSubstitutionRegExp(substitution.replace,
       scrubInputString(substitution.with, additionalReplacements)));
+
+  let elapsed = Date.now() - startTime;
+  d(`Spent ${elapsed} ms in getReplacementItems`);
 
   return [
     ...userDictionaryReplacements,

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ const textPreferenceChangedKeys = [
 
 let ipcMain, ipcRenderer, systemPreferences;
 let registeredWebContents = {};
+let listenerCount = 0;
 
 /**
  * Adds an `input` event listener to the given element (an <input> or
@@ -52,6 +53,13 @@ export default function performTextSubstitution(element, preferenceOverrides = n
   if (!systemPreferences || !systemPreferences.getUserDefault) {
     throw new Error(`Electron ${process.versions.electron} is not supported`);
   }
+
+  // Always clear the cache on startup, in case preference changes were made
+  // while the app was not running
+  if (listenerCount++ === 0 && canUseLocalStorage()) {
+    localStorage.removeItem(replacementItemsCacheKey);
+  }
+  d(`${listenerCount} total substitution listeners`);
 
   ipcRenderer.send(registerForPreferenceChangedIpcMessage);
 

--- a/src/regular-expressions.js
+++ b/src/regular-expressions.js
@@ -108,3 +108,24 @@ export function formatReplacement(match, replacement) {
   let [, left, right] = match;
   return `${left}${replacement}${right}`;
 }
+
+/**
+ * Can be used as the replacer parameter in `JSON.stringify` to serialize
+ * replacement items.
+ */
+export function regExpReplacer(key, value) {
+  if (value instanceof RegExp) return value.toString();
+  return value;
+}
+
+/**
+ * Can be used as the reviver parameter in `JSON.parse` to deserialize
+ * replacement items.
+ */
+export function regExpReviver(key, value) {
+  if (key === 'regExp') {
+    let [, regExp, flags] = value.match(/\/(.*)\/(.*)?/);
+    return new RegExp(regExp, flags || '');
+  }
+  return value;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -79,7 +79,7 @@ describe('the performTextSubstitution method', () => {
     input.typeText('Hello (c) . look here -> or there <- (1/2) is less than (3/4) (r) .... (1/3) (tm)... ');
     assert.equal(input.value, 'Hello © . look here → or there ← ½ is less than ¾ ® … ⅓ ™… ');
   });
-  
+
   it('should handle the infamous lbo', () => {
     let input = new MockInput('');
     performTextSubstitution(input, {


### PR DESCRIPTION
Creating regular expressions for each text substitution entry (and perhaps more costly: sorting them) is quite expensive when you have 1,000's of entries. 

This PR resolves #6 by stashing a local copy of the regular expressions, so we don't recreate them for each new listener. If the system text preferences change while a listener is subscribed, we'll still be forced to recreate them, so that case still performs poorly. Other potential optimizations include:

* Only handling the change notification once rather than once per subscriber
* Storing replacements in a [trie](https://en.wikipedia.org/wiki/Trie) for faster search