### PR TITLE
Add support for contenteditable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -206,6 +206,17 @@ function getReplacementItems({substitutions, useSmartQuotes, useSmartDashes}) {
 }
 
 /**
+ * Get the string value of Text, Elements, and form elements
+ *
+ * @param  {Element} element  The element whose text will be retrieved
+ * @return {String}           The text value of the element
+ */
+function getElementText(element) {
+  if (!element) return '';
+  return element.value || element.textContent;
+}
+
+/**
  * Subscribes to the `input` event and performs text substitution.
  *
  * @param  {EventTarget} element                      The DOM node to listen to
@@ -223,7 +234,8 @@ function addInputListener(element, replacementItems) {
       // Rather than search the entire input, we're just going to check the word
       // immediately before the caret (along with its surrounding whitespace).
       // This is to avoid substitutions after, say, a paste or an undo.
-      let searchStartIndex = lastIndexOfWhitespace(element.value, element.selectionEnd);
+      let value = getElementText(element);
+      let searchStartIndex = lastIndexOfWhitespace(value, element.selectionEnd);
       let lastWordBlock = element.value.substring(searchStartIndex, element.selectionEnd);
       let match = lastWordBlock.match(regExp);
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import performTextSubstitution from '../src';
 import MockInput from './mock-input';
+import MockContenteditable from './mock-contenteditable';
 
 describe('the performTextSubstitution method', () => {
   it('should error when not given an EventTarget', () => {
@@ -8,13 +9,17 @@ describe('the performTextSubstitution method', () => {
   });
 
   it('should replace text after an input event', () => {
-    let input = new MockInput('something, something');
-    performTextSubstitution(input, {
-      substitutions: [{ replace: 'shrug', with: '¯\\_(ツ)_/¯' }]
-    });
+    let text = 'something, something';
+    let targets = [new MockInput(text), new MockContenteditable(text)];
 
-    input.inputText(' shrug ');
-    assert.equal(input.value, 'something, something ¯\\_(ツ)_/¯ ');
+    targets.forEach(input => {
+      performTextSubstitution(input, {
+        substitutions: [{ replace: 'shrug', with: '¯\\_(ツ)_/¯' }]
+      });
+
+      input.inputText(' shrug ');
+      assert.equal(input.value, 'something, something ¯\\_(ツ)_/¯ ');
+    });
   });
 
   it('should stop replacing when unsubscribed', () => {

--- a/test/mock-contenteditable.js
+++ b/test/mock-contenteditable.js
@@ -1,0 +1,51 @@
+import EventTarget from 'event-target-shim';
+import {Observable} from 'rx-lite';
+
+export default class MockContenteditable extends EventTarget {
+  constructor(initialText = "") {
+    super();
+
+    this.textContent = initialText;
+    this.selectionStart = initialText.length;
+    this.selectionEnd = initialText.length;
+  }
+
+  inputText(text, dispatch = true) {
+    let before = this.textContent.substring(0, this.selectionStart);
+    let after = this.textContent.substring(this.selectionEnd, this.textContent.length);
+
+    this.textContent = `${before}${text}${after}`;
+    this.selectionStart = this.selectionEnd = this.textContent.length;
+
+    if (dispatch) this.dispatchEvent({type: 'input'});
+  }
+
+  typeText(text) {
+    return Observable.fromArray(text)
+      .subscribe((character) => this.inputText(character));
+  }
+
+  clearText() {
+    this.textContent = "";
+    this.selectionStart = 0;
+    this.selectionEnd = 0;
+  }
+
+  get value() {
+    return this.textContent;
+  }
+  set value(value) {
+    this.textContent = value;
+  }
+
+  /**
+   * Catch `textInput` events and change our underlying text.
+   */
+  dispatchEvent(evt) {
+    if (evt.type === 'textInput') {
+      this.inputText(evt.data, false);
+    } else {
+      super.dispatchEvent(evt);
+    }
+  }
+}


### PR DESCRIPTION
Add the initial support for contenteditable elements by abstracting how we retrieve element text. If it's a form element (`input[type=text]` or `textarea`) we'll grab the `value` otherwise fall back to `textContent` to support text nodes and regular elements.

Refs #11

### Questions

- I modified a single test to show one way it could be done. Would you like me to apply the same logic to the rest or would you like to try something else?