### PR TITLE
More contenteditable support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -236,7 +236,7 @@ function addInputListener(element, replacementItems) {
       // This is to avoid substitutions after, say, a paste or an undo.
       let value = getElementText(element);
       let searchStartIndex = lastIndexOfWhitespace(value, element.selectionEnd);
-      let lastWordBlock = element.value.substring(searchStartIndex, element.selectionEnd);
+      let lastWordBlock = value.substring(searchStartIndex, element.selectionEnd);
       let match = lastWordBlock.match(regExp);
 
       if (match && match.length === 3) {
@@ -318,6 +318,6 @@ function replaceText(element, {startIndex, endIndex}, newText) {
   element.selectionStart = startIndex;
   element.selectionEnd = endIndex;
 
-  d(`Replacing ${element.value.substring(startIndex, endIndex)} with ${newText}`);
+  d(`Replacing ${getElementText(element).substring(startIndex, endIndex)} with ${newText}`);
   element.dispatchEvent(textEvent);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -213,7 +213,9 @@ function getReplacementItems({substitutions, useSmartQuotes, useSmartDashes}) {
  */
 function getElementText(element) {
   if (!element) return '';
-  return element.value || element.textContent;
+  if (element.value) return element.value;
+  if (element.textContent.endsWith('\n')) return element.textContent.slice(0, -1);
+  return element.textContent;
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -194,7 +194,8 @@ function getReplacementItems({substitutions, useSmartQuotes, useSmartDashes}) {
   // so that an input event doesn't cause chained substitutions. Also sort
   // replacements by length, to handle nested substitutions.
   let userDictionaryReplacements = substitutions
-    .filter((substitution) => substitution.on !== false)
+    .filter((substitution) => substitution.on !== false &&
+      substitution.replace !== substitution.with)
     .sort((a, b) => b.replace.length - a.replace.length)
     .map((substitution) => getSubstitutionRegExp(substitution.replace,
       scrubInputString(substitution.with, additionalReplacements)));


### PR DESCRIPTION
This PR wraps up the changes started in https://github.com/CharlieHess/electron-text-substitutions/pull/12, mainly adding support for selection ranges. It also fixes an issue where if the replacement was the same as the candidate word, you could get into a reversed input scenario as it would continually reset your cursor position.