### PR TITLE
Bump up dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
   "dependencies": {
     "babel-runtime": "^6.9.2",
     "debug-electron": "0.0.1",
-    "lodash": "^4.13.1",
-    "rx-lite": "^4.0.8"
+    "lodash.foreach": "^4.5.0",
+    "lodash.reduce": "^4.6.0",
+    "lodash.some": "^4.6.0",
+    "lodash.values": "^4.3.0",
+    "rxjs": "^5.0.0-beta.12"
   }
 }

--- a/src/regular-expressions.js
+++ b/src/regular-expressions.js
@@ -1,4 +1,5 @@
-import {escapeRegExp, reduce} from 'lodash';
+import escapeRegExp from 'lodash.escaperegexp';
+import reduce from 'lodash.reduce';
 
 export const openingSingleQuote = '\u2018'; // ‘
 export const closingSingleQuote = '\u2019'; // ’

--- a/src/serial-subscription.js
+++ b/src/serial-subscription.js
@@ -1,0 +1,42 @@
+import {Subscription} from 'rxjs/Subscription';
+
+/**
+ * @export
+ * @class SerialSubscription
+ * Mimics behavior of SerialDisposable in RxJS v4,
+ * allows to add only single subscription. If new subscription's added,
+ * existing subscription will be unsubscribed.
+ *
+ * By design of RxJS v5 it is no longer recommended to manage subscription
+ * imperatively vis various kind of subscription, reason it only have single
+ * kind of composite subscription. This implementation is for interop between
+ * existing codebases.
+ * @extends {Subscription}
+ */
+export class SerialSubscription extends Subscription {
+  _currentSubscription = null;
+
+  /**
+   * Adds a tear down to be called during the unsubscribe() of this
+   * Subscription.
+   *
+   * If there's existing subscription, it'll be unsubscribed and
+   * removed.
+   *
+   * @param {TeardownLogic} teardown The additional logic to execute on
+   * teardown.
+   * @return {Subscription} Returns the Subscription used or created to be
+   * added to the inner subscriptions list. This Subscription can be used with
+   * `remove()` to remove the passed teardown logic from the inner subscriptions
+   * list.
+   */
+  add(teardown) {
+    if (this._currentSubscription) {
+      this.remove(this._currentSubscription);
+      this._currentSubscription.unsubscribe();
+      this._currentSubscription = null;
+    }
+
+    super.add(this._currentSubscription = teardown);
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -30,7 +30,7 @@ describe('the performTextSubstitution method', () => {
 
     input.inputText('disapproval ');
     assert.equal(input.value, 'everything I do deserves… ಠ_ಠ ');
-    disposable.dispose();
+    disposable.unsubscribe();
 
     input.inputText('and more disapproval.');
     assert.equal(input.value, 'everything I do deserves… ಠ_ಠ and more disapproval.');
@@ -120,7 +120,7 @@ describe('the performTextSubstitution method', () => {
 
     input.inputText('greetings ');
     assert.equal(input.value, 'Hello-- my name is \'Milo,\' how do you do? ');
-    disposable.dispose();
+    disposable.unsubscribe();
     input.clearText();
 
     performTextSubstitution(input, {

--- a/test/mock-contenteditable.js
+++ b/test/mock-contenteditable.js
@@ -1,5 +1,5 @@
 import EventTarget from 'event-target-shim';
-import {Observable} from 'rx-lite';
+import {Observable} from 'rxjs';
 
 export default class MockContenteditable extends EventTarget {
   constructor(initialText = "") {
@@ -21,7 +21,7 @@ export default class MockContenteditable extends EventTarget {
   }
 
   typeText(text) {
-    return Observable.fromArray(text)
+    return Observable.from(text)
       .subscribe((character) => this.inputText(character));
   }
 

--- a/test/mock-input.js
+++ b/test/mock-input.js
@@ -1,5 +1,5 @@
 import EventTarget from 'event-target-shim';
-import {Observable} from 'rx-lite';
+import {Observable} from 'rxjs';
 
 export default class MockInput extends EventTarget {
   constructor(initialText = "") {
@@ -21,7 +21,7 @@ export default class MockInput extends EventTarget {
   }
 
   typeText(text) {
-    return Observable.fromArray(text)
+    return Observable.from(text)
       .subscribe((character) => this.inputText(character));
   }
 


### PR DESCRIPTION
This PR bumps up dependencies of `lodash` and `rx` to latest, as well as import only necessary operator set instead of importing all modules.