### PR TITLE
Remove dispatchevent to default action

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -323,13 +323,10 @@ function lastIndexOfWhitespace(value, fromIndex) {
  * @param  {String} newText       The text being inserted
  */
 function replaceText(element, {startIndex, endIndex}, newText) {
-  let textEvent = document.createEvent('TextEvent');
-  textEvent.initTextEvent('textInput', true, true, null, newText);
-
   setSelectionRange(element, startIndex, endIndex);
 
   d(`Replacing ${getElementText(element).substring(startIndex, endIndex)} with ${newText}`);
-  element.dispatchEvent(textEvent);
+  document.execCommand('insertText', false, newText);
 }
 
 /**


### PR DESCRIPTION
This PR removes `dispatchEvent` to default action from untrusted event - from chrome M53, chrome does not allow to dispatch default action except `click` from untrusted event, such as event created from javascript (https://www.chromestatus.com/features/5718803933560832), creates regression to substitution behavior.

Instead, this PR invokes `document.execCommand` directly to fire up intended behavior.
There maybe better, legit way of invoking instead of `execCommand` - feel freely close / adress if there's other way around.