### PR TITLE
Trigger input validation for partial composition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 lib
+node_modules

--- a/src/index.js
+++ b/src/index.js
@@ -294,7 +294,18 @@ function addInputListener(element, replacementItems) {
   };
 
   const compositionStartListener = () => composition = true;
-  const compositionEndListener = () => composition = false;
+  const compositionEndListener = () => {
+    composition = false;
+
+    //force validate substitution state after composition completes.
+    //in case of some IME (KR for example) compositon end event won't be triggered unless
+    //final consonant are typed, while char itself can written without final consonant.
+    //This'll makes initial substitution doesn't replace text since it's suppressed then
+    //next substitution try to attempt replace first char which haven't triggered at those moment.
+    //to avoid those, force trigger input validation as soon as composition end event fires
+    ignoreEvent = false;
+    inputListener();
+  };
 
   element.addEventListener('compositionstart', compositionStartListener, true);
   element.addEventListener('compositionend', compositionEndListener, true);


### PR DESCRIPTION
This PR amends `compositionend` event listener to force trigger substitution validation once composition completes to avoid partial composition skips substitution causes next substitute try first once instead. I've updated comment for explaining its behavior but I assume it can be confuse for non-CJK users, added example below how does it actually works before vs. after.

To add bit more detail about implementation, I believe there maybe more graceful way to handle instead of dealing with flags / force retrigger validation but that might need additional sufficient time to look into IME behavior, as well as refactoring codes in further (Rx, maybe). This is immediate workaround to support CJK user do not feel inconveniences.

example)
```
original: ...하하...하
changed :…하하…하 (... substitues to ellipsis …)


current: ...하하...하
                 ↑
                 triggers substitution, since first substitute validation suppressed by composition end and not retriggered
current after: …하.하.
                  ↑
                  cursor here, substitute first one


changed: ...하하...하
               ↑ ↑
               triggers substitution, as soon as composition end to validate exist string, then move to next substitution if asked
changed :…하하…하
               ↑
               cursor here, substitute both
```