### PR TITLE
Replace debug-electron with debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.9.2",
-    "debug-electron": "0.0.1",
+    "debug": "^2.5.1",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.foreach": "^4.5.0",
     "lodash.reduce": "^4.6.0",

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import {getSubstitutionRegExp, getSmartQuotesRegExp, getSmartDashesRegExp,
 import {isUndoRedoEvent, isBackspaceEvent} from './keyboard-utils';
 
 const packageName = 'electron-text-substitutions';
-const d = require('debug-electron')(packageName);
+const d = require('debug')(packageName);
 
 const registerForPreferenceChangedIpcMessage = `${packageName}-register-renderer`;
 const unregisterForPreferenceChangedIpcMessage = `${packageName}-unregister-renderer`;


### PR DESCRIPTION
debug-electron is no longer needed (and in fact, old versions are busted), the original issue is patched in debug itself