### PR TITLE
Don't return remote objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "debug": "^2.5.1",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.foreach": "^4.5.0",
+    "lodash.isfunction": "^3.0.8",
+    "lodash.isobject": "^3.0.2",
     "lodash.reduce": "^4.6.0",
     "lodash.some": "^4.6.0",
     "lodash.values": "^4.3.0",

--- a/src/preference-helpers.js
+++ b/src/preference-helpers.js
@@ -25,10 +25,23 @@ const textPreferenceChangedKeys = [
  * @return {Object}.useSmartDashes  True if smart dashes are enabled
  */
 export function readSystemTextPreferences() {
+  let substitutions = systemPreferences.getUserDefault(userDefaultsTextSubstitutionsKey, 'array') || [];
+
+  if (process.type === 'renderer') {
+    const noRemoteObjects = [];
+    substitutions.forEach((sub) => {
+      noRemoteObjects.push({ ...sub });
+    });
+    substitutions = noRemoteObjects;
+  }
+
+  const useSmartQuotes = systemPreferences.getUserDefault(userDefaultsSmartQuotesKey, 'boolean');
+  const useSmartDashes = systemPreferences.getUserDefault(userDefaultsSmartDashesKey, 'boolean');
+
   return {
-    substitutions: systemPreferences.getUserDefault(userDefaultsTextSubstitutionsKey, 'array') || [],
-    useSmartQuotes: systemPreferences.getUserDefault(userDefaultsSmartQuotesKey, 'boolean'),
-    useSmartDashes: systemPreferences.getUserDefault(userDefaultsSmartDashesKey, 'boolean')
+    substitutions,
+    useSmartQuotes,
+    useSmartDashes
   };
 }
 

--- a/test/contains-remote-object.js
+++ b/test/contains-remote-object.js
@@ -1,0 +1,22 @@
+import isObject from 'lodash.isobject';
+import isFunction from 'lodash.isfunction';
+
+/**
+ * Determines if an object is, or contains, an Electron remote object.
+ * Under the surface, getting or setting properties on remote objects triggers
+ * synchronous IPC messages. So we want to avoid storing them at all costs.
+ *
+ * Refer to https://github.com/electron/electron/blob/master/docs/api/remote.md#remote-objects.
+ *
+ * @param  {Object} obj An object to test
+ * @return {Boolean}    True if it is a remote object, false otherwise
+ */
+export function containsRemoteObject(obj) {
+  if (!process || !process.atomBinding) return false;
+  if (!isObject(obj) && !isFunction(obj)) return false;
+
+  const v8util = process.atomBinding('v8_util');
+  if (v8util.getHiddenValue(obj, 'atomId')) return true;
+
+  return Object.keys(obj).find((x) => containsRemoteObject(obj[x]));
+}

--- a/test/preference-helpers.js
+++ b/test/preference-helpers.js
@@ -1,0 +1,9 @@
+import assert from 'assert';
+import {readSystemTextPreferences} from '../src/preference-helpers';
+import {containsRemoteObject} from './contains-remote-object';
+
+describe('the readSystemTextPreferences method', () => {
+  it('should not return remote objects', () => {
+    assert(!containsRemoteObject(readSystemTextPreferences()));
+  });
+});


### PR DESCRIPTION
`readSystemTextPreferences`, if called from a renderer, will happily return an array of remote objects that, when accessed, will incur `ipc.sendSync` penalties. This seems like a shortcoming of `systemPreferences.getUserDefault` because, so long as the result contains only primitives they'll be copied by value. The temporary workaround is to copy them ourselves (ugh).