### PR TITLE
Avoid leaking input nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "lodash.reduce": "^4.6.0",
     "lodash.some": "^4.6.0",
     "lodash.values": "^4.3.0",
-    "rxjs": "^5.0.0-beta.12",
-    "rxjs-serial-subscription": "^0.1.1"
+    "rxjs": "^5.0.0-beta.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "lodash.reduce": "^4.6.0",
     "lodash.some": "^4.6.0",
     "lodash.values": "^4.3.0",
-    "rxjs": "^5.0.0-beta.12"
+    "rxjs": "^5.1.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const d = require('debug')(packageName);
 
 const registerForPreferenceChangedIpcMessage = `${packageName}-register-renderer`;
 const unregisterForPreferenceChangedIpcMessage = `${packageName}-unregister-renderer`;
-const preferenceChangedIpcMessage = `${packageName}-preference-changed`;
+export const preferenceChangedIpcMessage = `${packageName}-preference-changed`;
 
 let ipcMain, ipcRenderer, systemPreferences;
 let replacementItems = null;

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,6 @@ import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/debounceTime';
 import {Observable} from 'rxjs/Observable';
 import {Subscription} from 'rxjs/Subscription';
-import SerialSubscription from 'rxjs-serial-subscription';
 import {readSystemTextPreferences, onPreferenceChanged} from './preference-helpers';
 import {getSubstitutionRegExp, getSmartQuotesRegExp, getSmartDashesRegExp,
   scrubInputString, formatReplacement, regExpReplacer, regExpReviver} from './regular-expressions';

--- a/test/index.js
+++ b/test/index.js
@@ -143,7 +143,7 @@ describe('the performTextSubstitution method', () => {
     input.selectionStart = 0;
     input.selectionEnd = 0;
 
-    performTextSubstitution(input, {
+    subscription = performTextSubstitution(input, {
       substitutions: [{ replace: 'greetings', with: 'Hello-- my name is \'Milo,\' how do you do?' }],
       useSmartQuotes: true,
       useSmartDashes: true


### PR DESCRIPTION
We're hooking [`ipcRenderer`](https://github.com/CharlieHess/electron-text-substitutions/blob/master/src/index.js#L67) and referencing the input DOM node inside that listener. Be sure to unhook this event on `unsubscribe`.