### PR TITLE
Handle remote objects better

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "electron-text-substitutions",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "description": "Substitute text in an input field based on OS X System Preferences",
   "main": "lib/index.js",
   "scripts": {
     "compile": "babel -d lib/ src/",
     "prepublish": "npm run compile",
-    "test": "electron-mocha --renderer ./test"
+    "test": "electron-mocha ./test"
   },
   "repository": {
     "type": "git",

--- a/src/preference-helpers.js
+++ b/src/preference-helpers.js
@@ -25,16 +25,9 @@ const textPreferenceChangedKeys = [
  * @return {Object}.useSmartDashes  True if smart dashes are enabled
  */
 export function readSystemTextPreferences() {
+  if (process.type === 'renderer') throw new Error('Not in an Electron browser context');
+
   let substitutions = systemPreferences.getUserDefault(userDefaultsTextSubstitutionsKey, 'array') || [];
-
-  if (process.type === 'renderer') {
-    const noRemoteObjects = [];
-    substitutions.forEach((sub) => {
-      noRemoteObjects.push({ ...sub });
-    });
-    substitutions = noRemoteObjects;
-  }
-
   const useSmartQuotes = systemPreferences.getUserDefault(userDefaultsSmartQuotesKey, 'boolean');
   const useSmartDashes = systemPreferences.getUserDefault(userDefaultsSmartDashesKey, 'boolean');
 
@@ -43,6 +36,14 @@ export function readSystemTextPreferences() {
     useSmartQuotes,
     useSmartDashes
   };
+}
+
+/**
+ * If we've required this module remotely, we want to serialize the text
+ * preferences first, to avoid any remote objects in the result.
+ */
+export function readSystemTextPreferencesJSON() {
+  return JSON.stringify(readSystemTextPreferences());
 }
 
 /**


### PR DESCRIPTION
If you have a very large array of text substitutions, `readSystemTextPreferences` is extremely slow when called from a renderer process. This is because of some overly clever code that tried to avoid including remote objects in the result:

```js
if (process.type === 'renderer') {
  const noRemoteObjects = [];
  substitutions.forEach((sub) => {
    noRemoteObjects.push({ ...sub });
  });
  substitutions = noRemoteObjects;
}
```

While this code accomplished its goal, iterating the array of substitutions and performing the copy **itself** results in 3 `ipcRenderer.sendSync` calls **per substitution**, because each property `get` on the text substitution object is mapped to a `sendSync` (since this object lives in the main process).

![](https://media1.giphy.com/media/S7aF5YPXDMMwM/giphy-downsized.gif)

What we actually want to do is:

1. `require` the method using `remote`
1. Serialize (`JSON.stringify`) the array _in the main process_, so that no objects are sent over IPC
1. Parse the response in the renderer process, restoring the objects

To accomplish that, we'll add a `readSystemTextPreferencesJSON` method. Now you can do the following in a renderer:

``` js
const remote = require('electron').remote;
const preferencesAsJSON = remote.require(
  'electron-text-substitutions/preference-helpers'
).readSystemTextPreferencesJSON;
const textPreferences = JSON.parse(preferencesAsJSON());
```