### PR TITLE
Fixes: JSON parse error when changing text preferences

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export default function performTextSubstitution(element, preferenceOverrides = n
 
   let currentAttach = addInputListener(element, replacementItems);
 
-  const preferenceChangedListener = (serializedItems) => {
+  const preferenceChangedListener = (ev, serializedItems) => {
     d(`User modified text preferences, reattaching listener`);
     replacementItems = JSON.parse(serializedItems, regExpReviver);
 


### PR DESCRIPTION
The data is contained in the second argument, the first argument is the event.

The error can be reproduced by changing text preferences while an application using this module is open.